### PR TITLE
a few more things...

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ some points to keep note too:
 
 - If you want to make that persistent across shells and reboots do instead...
 
-   `./kubLocalSetup shellinit >> ˜/.bash_profile`
+   `./kubLocalSetup shellinit >> ~/.bash_profile`
 - If you want to validate the environment variables we just set, run...
 
    `./kubLocalSetup shellinit`

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ All aspects of your cluster setup can be customized with environment variables. 
    You can create/update a *~/.dockercfg* file at any time
    by running `docker login <registry>.<domain>`. All nodes will get it automatically,
    at 'vagrant up', given any modification or update to that file.
+
+ - **ETCD_CLUSTER_SIZE** sets the number of nodes in the default built-in etcd
+   cluster.
+
+   Defaults to **3** (or the total number of nodes of the cluster if lower).
+
  - **KUBERNETES_VERSION** defines the specific kubernetes version being used.
 
    Currently we are defaulting to **0.11.0**, which is the last released version.
@@ -169,20 +175,30 @@ $(./kubLocalSetup shellinit)
 ### Set-up cluster
 
 ```
-vagrant up master
-```
-
-Wait until ```master``` has finished downloading Kubernetes binaries and provisioned a Docker mirror cache. This can take a few minutes depending on your Internet speed. After that, bring up a couple minions:
-
-```
 NODE_MEM=2048 NODE_CPUS=1 NUM_INSTANCES=2 vagrant up
 ```
 
-## Usage
+This will start the `master` and 2 `minion` nodes. On them a local etcd
+cluster will be bootstrapped, Kubernetes binaries will be downloaded and
+all needed services started, as a *bonus* a docker mirror cache will be
+provisioned in the `master`, to speed up container provisioning. This
+can take a little bit depending on your Internet connection speed.
 
-You're now ready to use your Kubernetes cluster.
+Please do note that, at any time, you can increase the number of running
+`minion` VMs by increasing the `NUM_INSTANCES` value in subsequent
+`vagrant up` invocations.
 
-If you just want to test something simple, start with [Kubernetes examples](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/).
+### Usage
+
+Congratulations! You're now ready to use your Kubernetes cluster.
+
+If you just want to test something simple, start with [Kubernetes examples]
+(https://github.com/GoogleCloudPlatform/kubernetes/blob/master/examples/).
+
+For a more elaborate scenario [here]
+(https://github.com/pires/kubernetes-elasticsearch-cluster) you'll find all
+you need to get a scalable Elasticsearch cluster on top of Kubernetes in no
+time.
 
 ## Licensing
 

--- a/master.yaml
+++ b/master.yaml
@@ -1,15 +1,30 @@
 #cloud-config
 
 ---
-write_files:
-- path: /opt/bin/waiter.sh
-  owner: root
-  content: |
-    #! /usr/bin/bash
-    until curl http://127.0.0.1:4001/v2/machines; do sleep 2; done
+write-files:
+  - path: /etc/conf.d/nfs
+    permissions: '0644'
+    content: |
+      OPTS_RPC_MOUNTD=""
+  - path: /opt/bin/wupiao
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      # [w]ait [u]ntil [p]ort [i]s [a]ctually [o]pen
+      [ -n "$1" ] && [ -n "$2" ] && \
+        until curl -o /dev/null -sIf http://${1}:${2}; do \
+          sleep 1 && echo .;
+        done;
+      exit $?
+
 coreos:
   fleet:
     public-ip: $public_ipv4
+    etcd-servers: http://$private_ipv4:2379
+    metadata: "role=master"
+  flannel:
+    interface: eth1
+
   units:
     - name: setup-network-environment.service
       command: start
@@ -31,123 +46,118 @@ coreos:
       command: start
       content: |
         [Unit]
-        Description=etcd
-        Requires=setup-network-environment.service
-        After=setup-network-environment.service
+        Description=etcd 2.0
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
 
         [Service]
-        EnvironmentFile=/etc/network-environment
-        User=etcd
-        PermissionsStartOnly=true
-        ExecStart=/usr/bin/etcd \
-        --name $public_ipv4 \
-        --addr $public_ipv4:4001 \
-        --bind-addr 0.0.0.0 \
-        --cluster-active-size 1 \
-        --data-dir /var/lib/etcd \
-        --http-read-timeout 86400 \
-        --peer-addr $public_ipv4:7001 \
-        --snapshot true
         Restart=always
-        RestartSec=10s
-    - name: fleet.socket
-      command: start
-      content: |
-        [Socket]
-        ListenStream=/var/run/fleet.sock
-    - name: fleet.service
-      command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=etcd.service
-        After=etcd.service
-        Wants=fleet.socket
-        After=fleet.socket
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        EnvironmentFile=/etc/environment
+        TimeoutStartSec=0
+        SyslogIdentifier=writer_process
+        LimitNOFILE=40000
+        ExecStartPre=-/usr/bin/docker kill etcd
+        ExecStartPre=-/usr/bin/docker rm etcd
+        ExecStartPre=/usr/bin/docker pull quay.io/coreos/etcd:v2.0.4
+        ExecStart=/bin/bash -c "/usr/bin/docker run \
+            --net=host \
+            -p 2379:2379 \
+            -p 2380:2380 \
+            -p 4001:4001 \
+            -p 7001:7001 \
+            --name etcd \
+            -v /opt/etcd:/opt/etcd \
+            -v /usr/share/ca-certificates/:/etc/ssl/certs \
+            quay.io/coreos/etcd:v2.0.4 \
+            -data-dir /opt/etcd \
+            -name __NAME__ \
+            -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
+            -advertise-client-urls http://$COREOS_PRIVATE_IPV4:2379,http://$COREOS_PRIVATE_IPV4:4001 \
+            -initial-cluster-token k8s_etcd \
+            -listen-peer-urls http://0.0.0.0:2380 \
+            -initial-advertise-peer-urls http://$COREOS_PRIVATE_IPV4:2380 \
+            -initial-cluster __ETCD_SEED_CLUSTER__ \
+            -initial-cluster-state new"
+        ExecStop=/usr/bin/docker kill etcd
 
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://127.0.0.1:4001"
-        Environment="FLEET_METADATA=role=master"
-        ExecStart=/usr/bin/fleetd
-        Restart=always
-        RestartSec=10s
-    - name: etcd-waiter.service
+        [X-Fleet]
+        Conflicts=etcd*
+    - name: flanneld.service
       command: start
-      content: |
-        [Unit]
-        Description=etcd waiter
-        Wants=network-online.target
-        Wants=etcd.service
-        After=etcd.service
-        After=network-online.target
-        Before=flannel.service
-
-        [Service]
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/waiter.sh
-        ExecStart=/usr/bin/bash /opt/bin/waiter.sh
-        RemainAfterExit=true
-        Type=oneshot
+      drop-ins:
+        - name: 50-network-config.conf
+          content: |
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
+            # as we need to turn eth1 as the default interface
+            # https://github.com/coreos/bugs/issues/228 is sorted
+            # see notes in https://github.com/coreos/flannel/pull/137
+            ExecStart=
+            ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
+                /usr/bin/docker run --net=host --privileged=true --rm \
+                    --volume=/run/flannel:/run/flannel \
+                    --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
+                    --env-file=/run/flannel/options.env \
+                    --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
+                    quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true --iface=eth1
     - name: docker-cache.service
       command: start
       content: |
         [Unit]
         Description=Docker cache proxy
-        Wants=network-online.target
-        Wants=docker.service
-        After=docker.service
-        After=docker-online.target
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
 
         [Service]
-        ExecStart=/usr/bin/docker run --net host -d --name docker-registry \
-        -e STANDALONE=false \
-        -e MIRROR_SOURCE=https://registry-1.docker.io \
-        -e MIRROR_SOURCE_INDEX=https://index.docker.io \
-        registry
-        RemainAfterExit=true
-        Type=oneshot
-    - name: flannel.service
+        Restart=always
+        TimeoutStartSec=0
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        ExecStartPre=-/usr/bin/docker kill docker-registry
+        ExecStartPre=-/usr/bin/docker rm docker-registry
+        ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
+        ExecStart=/usr/bin/docker run --rm --net host --name docker-registry \
+            -e STANDALONE=false \
+            -e MIRROR_SOURCE=https://registry-1.docker.io \
+            -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+            -e MIRROR_TAGS_CACHE_TTL=1800 \
+            quay.io/devops/docker-registry:latest
+    - name: fleet.service
       command: start
-      content: |
-        [Unit]
-        Wants=etcd-waiter.service
-        After=etcd-waiter.service
-        Requires=etcd.service
-        After=etcd.service
-        After=network-online.target
-        Wants=network-online.target
-        Description=flannel is an etcd backed overlay network for containers
-
-        [Service]
-        Type=notify
-        ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/flanneld
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
-        ExecStartPre=-/usr/bin/etcdctl mk /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
-        ExecStart=/opt/bin/flanneld --iface=eth1
     - name: docker.service
       command: start
-      content: |
-        [Unit]
-        After=flannel.service
-        Wants=flannel.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
-
-        [Service]
-        EnvironmentFile=/run/flannel/subnet.env
-        ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
-
-        [Install]
-        WantedBy=multi-user.target
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Unit]
+            Requires=docker-cache.service
+            After=docker-cache.service
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
+    - name: rpc-statd.service
+      command: start
+      enable: true
+    # - name: mnt-data.mount
+    #   command: start
+    #   content: |
+    #     [Mount]
+    #     What=filer.your.domain:/volX/dataY
+    #     Where=/mnt/dataY
+    #     Type=nfs
     - name: kube-apiserver.service
       command: start
       content: |
         [Unit]
         Description=Kubernetes API Server
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=etcd.service
-        After=etcd.service
+        Requires=etcd.service docker-cache.service
+        After=etcd.service docker-cache.service
 
         [Service]
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
@@ -157,7 +167,7 @@ coreos:
         --address=0.0.0.0 \
         --port=8080 \
         --portal_net=10.100.0.0/16 \
-        --etcd_servers=http://127.0.0.1:4001 \
+        --etcd_servers=http://127.0.0.1:2379 \
         --public_address_override=172.17.8.101 \
         --logtostderr=true
         Restart=always

--- a/node.yaml
+++ b/node.yaml
@@ -1,25 +1,29 @@
 #cloud-config
 
+---
+write-files:
+  - path: /etc/conf.d/nfs
+    permissions: '0644'
+    content: |
+      OPTS_RPC_MOUNTD=""
+  - path: /opt/bin/wupiao
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      # [w]ait [u]ntil [p]ort [i]s [a]ctually [o]pen
+      [ -n "$1" ] && [ -n "$2" ] && while ! curl --output /dev/null \
+        --silent --head --fail \
+        http://${1}:${2}; do sleep 1 && echo -n .; done;
+      exit $?
 coreos:
   fleet:
     public-ip: $public_ipv4
-  units:
-    - name: etcd.service
-      mask: true
-    - name: fleet.service
-      command: start
-      content: |
-        [Unit]
-        Description=fleet daemon
-        Wants=fleet.socket
-        After=fleet.socket
+    etcd-servers: http://$private_ipv4:2379
+    metadata: "role=minion"
+  flannel:
+    interface: eth1
 
-        [Service]
-        Environment="FLEET_ETCD_SERVERS=http://172.17.8.101:4001"
-        Environment="FLEET_METADATA=role=minion"
-        ExecStart=/usr/bin/fleetd
-        Restart=always
-        RestartSec=10s
+  units:
     - name: setup-network-environment.service
       command: start
       content: |
@@ -30,45 +34,96 @@ coreos:
         After=network-online.target
 
         [Service]
-        ExecStartPre=-/usr/bin/mkdir -p /opt/bin
+        ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
         ExecStart=/opt/bin/setup-network-environment
         RemainAfterExit=yes
         Type=oneshot
-    - name: flannel.service
+    - name: etcd.service
       command: start
       content: |
         [Unit]
-        After=network-online.target
-        Wants=network-online.target
-        Description=flannel is an etcd backed overlay network for containers
+        Description=etcd 2.0
+        Requires=early-docker.service
+        After=early-docker.service
+        Before=early-docker.target
 
         [Service]
-        Type=notify
-        ExecStartPre=/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/k8s/flanneld
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/flanneld
-        ExecStart=/opt/bin/flanneld --iface=eth1 --etcd-endpoints http://172.17.8.101:4001
+        Restart=always
+        RestartSec=5
+        Environment="TMPDIR=/var/tmp/"
+        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+        EnvironmentFile=/etc/environment
+        TimeoutStartSec=0
+        SyslogIdentifier=writer_process
+        LimitNOFILE=40000
+        ExecStartPre=-/usr/bin/docker kill etcd
+        ExecStartPre=-/usr/bin/docker rm etcd
+        ExecStartPre=/usr/bin/docker pull quay.io/coreos/etcd:v2.0.4
+        ExecStart=/bin/bash -c "/usr/bin/docker run \
+            --net=host \
+            -p 2379:2379 \
+            -p 2380:2380 \
+            -p 4001:4001 \
+            -p 7001:7001 \
+            --name etcd \
+            -v /opt/etcd:/opt/etcd \
+            -v /usr/share/ca-certificates/:/etc/ssl/certs \
+            quay.io/coreos/etcd:v2.0.4 \
+            -data-dir /opt/etcd \
+            -name __NAME__ \
+            -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
+            -advertise-client-urls http://$COREOS_PRIVATE_IPV4:2379,http://$COREOS_PRIVATE_IPV4:4001 \
+            -initial-cluster-token k8s_etcd \
+            -listen-peer-urls http://0.0.0.0:2380 \
+            -initial-advertise-peer-urls http://$COREOS_PRIVATE_IPV4:2380 \
+            -initial-cluster __ETCD_SEED_CLUSTER__ \
+            -initial-cluster-state new"
+        ExecStop=/usr/bin/docker kill etcd
+
+        [X-Fleet]
+        Conflicts=etcd*
+    - name: flanneld.service
+      command: start
+      drop-ins:
+        - name: 50-network-config.conf
+          content: |
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
+            # as we need to turn eth1 as the default interface
+            # https://github.com/coreos/bugs/issues/228 is sorted
+            # see notes in https://github.com/coreos/flannel/pull/137
+            ExecStart=
+            ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
+                /usr/bin/docker run --net=host --privileged=true --rm \
+                    --volume=/run/flannel:/run/flannel \
+                    --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
+                    --env-file=/run/flannel/options.env \
+                    --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
+                    quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true --iface=eth1
+    - name: fleet.service
+      command: start
     - name: docker.service
       command: start
-      content: |
-        [Unit]
-        After=flannel.service
-        Wants=flannel.service
-        Description=Docker Application Container Engine
-        Documentation=http://docs.docker.io
-
-        [Service]
-        EnvironmentFile=/run/flannel/subnet.env
-        ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker --registry-mirror=http://172.17.8.101:5000 -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
-
-        [Install]
-        WantedBy=multi-user.target
+      drop-ins:
+        - name: 51-docker-mirror.conf
+          content: |
+            [Service]
+            Environment=DOCKER_OPTS='--registry-mirror=http://172.17.8.101:5000'
+    - name: rpc-statd.service
+      command: start
+      enable: true
+    # - name: mnt-data.mount
+    #   command: start
+    #   content: |
+    #     [Mount]
+    #     What=filer.your.domain:/volX/dataY
+    #     Where=/mnt/dataY
+    #     Type=nfs
     - name: cadvisor.service
       command: start
-      content: |-
+      content: |
         [Unit]
         Description=cAdvisor Service
         After=docker.service
@@ -93,9 +148,11 @@ coreos:
         [Service]
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        # wait for kubernetes master to be up and ready
+        ExecStartPre=/opt/bin/wupiao 172.17.8.101 8080
         ExecStart=/opt/bin/kube-proxy \
-        --etcd_servers=http://172.17.8.101:4001 \
-        --logtostderr=true
+          --etcd_servers=http://172.17.8.101:2379 \
+          --logtostderr=true
         Restart=always
         RestartSec=10
     - name: kube-kubelet.service
@@ -111,12 +168,14 @@ coreos:
         EnvironmentFile=/etc/network-environment
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
+        # wait for kubernetes master to be up and ready
+        ExecStartPre=/opt/bin/wupiao 172.17.8.101 8080
         ExecStart=/opt/bin/kubelet \
-        --address=0.0.0.0 \
-        --port=10250 \
-        --hostname_override=$public_ipv4 \
-        --api_servers=172.17.8.101:8080 \
-        --logtostderr=true
+          --address=0.0.0.0 \
+          --port=10250 \
+          --hostname_override=$public_ipv4 \
+          --api_servers=172.17.8.101:8080 \
+          --logtostderr=true
         Restart=always
         RestartSec=10
   update:


### PR DESCRIPTION
  - more idiomatic (CoreOS centric) cloud-configs.
  - adds built-in etcd (v2) clustering.
  - uses CoreOS built-in flanneld.
  - the docker-caching image used is now 10 times smaller.
    for faster master's startup times.
  - add tweaks to cloud-config for proper NFS behaviour.
  - delay k8s' minion init until master's k8s machinery is
     up and ready, as this allows all VMs to be started at
     same time.
  - improve documentation.

---
*fwiw* looks _sane_ in my side :smiley: 