### PR TITLE
only start docker in the minion nodes after the master's docker-cache is up

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -115,6 +115,7 @@ coreos:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
+            ExecStartPre=/opt/bin/wupiao 172.17.8.101 5000
             Environment=DOCKER_OPTS='--registry-mirror=http://172.17.8.101:5000'
     - name: rpc-statd.service
       command: start


### PR DESCRIPTION
lets spare as much bandwidth as we can. (only matters atm for cadvisor)
