### PR TITLE
hotfix for #43.

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -124,7 +124,7 @@ coreos:
         ExecStartPre=/usr/bin/docker pull quay.io/devops/docker-registry:latest
         # GUNICORN_OPTS is an workaround for
         # https://github.com/docker/docker-registry/issues/892
-        ExecStart=/usr/bin/docker run --rm --restart always --net host --name docker-registry \
+        ExecStart=/usr/bin/docker run --restart always --net host --name docker-registry \
             -e STANDALONE=false \
             -e GUNICORN_OPTS=[--preload] \
             -e MIRROR_SOURCE=https://registry-1.docker.io \


### PR DESCRIPTION
breakage was introduced by a typo in c39c967a8. closes #43 
