### PR TITLE
Minor corrections to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ cluster setup with **[Vagrant](https://www.vagrantup.com)** (1.7.2+) and
 
 On **MacOS X** (and assuming you have [homebrew](http://brew.sh) already installed) run
 
-   `brew install wget fleetctl`
+```
+brew update
+brew install wget fleetctl
+```
 
 ## Deploy Kubernetes
 
@@ -31,8 +34,10 @@ vagrant up
 
 Verify if cluster is up & running
 ```
-fleetctl list-machines
+fleetctl --endpoint=http://172.17.8.101:4001 list-machines
 ```
+
+NOTE: Once the installation process is complete, you should not have to provide the `--endpoint` argument.
 
 You should see something like
 ```


### PR DESCRIPTION
- Add a `brew update` command before installing fleetctl to ensure
  that we get the latest version. Without this, running `fleetctl
  list-machines` will show a warning saying fleetctl is older than
  the cluster it is communicating with.

- Add an `--endpoing` argument to the first `fleetctl` command to
  ensure that it talks to the etcd endpoint in the VM and not the
  localhost.