### PR TITLE
fix privileged mode

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -169,6 +169,7 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-apiserver
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
+        --allow_privileged=true \
         --address=0.0.0.0 \
         --port=8080 \
         --portal_net=10.100.0.0/16 \


### PR DESCRIPTION
Hi,
i would like to install docker ui on my minions, but i could not run the pods with your setup. The allow_privileged flag must be set on the api-server as well.
Regards
Bernd