### PR TITLE
create dns replicationController and service only when uncreated

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -207,9 +207,26 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 -e "s|__DNS_UPSTREAM_SERVERS__|#{DNS_UPSTREAM_SERVERS}|g" \
               dns-controller.yaml.tmpl > ../temp/dns-controller.yaml
             cd ..
-            kubectl create -f temp/dns-controller.yaml
-            kubectl create -f dns/dns-service.yaml
           EOT
+
+          res, uri.path = nil, '/api/v1beta1/replicationControllers/kube-dns'
+          begin
+            res = Net::HTTP.get_response(uri)
+          rescue
+          end
+          if not res.is_a? Net::HTTPSuccess
+            system "kubectl create -f temp/dns-controller.yaml"
+          end
+
+          res, uri.path = nil, '/api/v1beta1/services/kube-dns'
+          begin
+            res = Net::HTTP.get_response(uri)
+          rescue
+          end
+          if not res.is_a? Net::HTTPSuccess
+            system "kubectl create -f dns/dns-service.yaml"
+          end
+
         end
       end
 


### PR DESCRIPTION
This prevents 2 errors when dns controller and service are already created.
This also prepares for windows-based provisioning:
- For windows (mingw) kubectl must be installed at coreos, because it needs *nix.
- When installing within coreos the commands may not return an error, that crashes the vagrant up process, so checking for availability is needed