### PR TITLE
Feature/windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can change the number of minions and/or the Kubernetes version by setting en
 vagrant up
 ```
 
+### *nix host
+
 Kubernetes cluster is ready. but you need to set-up some environment variables that we have already provisioned for you. In the current terminal windo, run:
 
 ```
@@ -38,6 +40,15 @@ source ~/.bash_profile
 ```
 
 New terminal windows will have this set for you.
+
+### Windows host
+
+On windows kubectl is installed on the master node in the ```/opt/bin``` directory. To manage your kubernetes cluster, ssh into the master node and run kubectl from there.
+
+```
+vagrant ssh master
+kubectl cluster-info
+```
 
 ## Clean-up
 
@@ -164,6 +175,9 @@ you which to mount the allowed syntax is...
 # if the mount is enabled or disabled by default. default is `true`.
   disabled: false
 ```
+
+#### Windows
+For windows the [vagrant-winnfsd plugin](https://github.com/GM-Alex/vagrant-winnfsd) is installed to enable nfs shares.
 
 ## TL;DR
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -172,16 +172,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if vmName == "master"
         kHost.trigger.before [:up, :provision] do
           info "Setting Kubernetes version #{KUBERNETES_VERSION}"
+          sedInplaceArg = OS.mac? ? " ''" : ""
           system "cp setup.tmpl temp/setup"
-          system "sed -e 's|__KUBERNETES_VERSION__|#{KUBERNETES_VERSION}|g' -i ./temp/setup"
-          system "sed -e 's|__MASTER_IP__|#{MASTER_IP}|g' -i ./temp/setup"
+          system "sed -e 's|__KUBERNETES_VERSION__|#{KUBERNETES_VERSION}|g' -i#{sedInplaceArg} ./temp/setup"
+          system "sed -e 's|__MASTER_IP__|#{MASTER_IP}|g' -i#{sedInplaceArg} ./temp/setup"
           system "chmod +x temp/setup"
           
           info "Configuring Kubernetes cluster DNS..."
           system "cp dns/dns-controller.yaml.tmpl temp/dns-controller.yaml"
-          system "sed -e 's|__MASTER_IP__|#{MASTER_IP}|g' -i ./temp/dns-controller.yaml"
-          system "sed -e 's|__DNS_DOMAIN__|#{DNS_DOMAIN}|g' -i ./temp/dns-controller.yaml"
-          system "sed -e 's|__DNS_UPSTREAM_SERVERS__|#{DNS_UPSTREAM_SERVERS}|g' -i ./temp/dns-controller.yaml"
+          system "sed -e 's|__MASTER_IP__|#{MASTER_IP}|g' -i#{sedInplaceArg} ./temp/dns-controller.yaml"
+          system "sed -e 's|__DNS_DOMAIN__|#{DNS_DOMAIN}|g' -i#{sedInplaceArg} ./temp/dns-controller.yaml"
+          system "sed -e 's|__DNS_UPSTREAM_SERVERS__|#{DNS_UPSTREAM_SERVERS}|g' -i#{sedInplaceArg} ./temp/dns-controller.yaml"
         end
 
         if OS.windows?

--- a/setup.tmpl
+++ b/setup.tmpl
@@ -13,6 +13,17 @@ scream () {
 case "$PLATFORM" in
   darwin|linux)
     targetDir="/usr/local/bin"
+    homeDir="~"
+    if [[ -r /etc/os-release ]]; then
+      . /etc/os-release
+      if [[ $ID = coreos ]]; then
+        targetDir="/opt/bin"
+        homeDir="/home/core"
+        unlink ${homeDir}/.bash_profile
+        cp /usr/share/skel/.bash_profile ${homeDir}/.bash_profile
+        chmod 775 ${homeDir}/.bash_profile
+      fi
+    fi
     ;;
   *)
     scream "Unknown or unsupported platform: ${PLATFORM}"
@@ -27,11 +38,11 @@ if [[ "$#" -eq 1 && "$1" == "install"  ]] ; then
 
   # TODO use sed to replace current values, if any
   echo "Setting environment variables.."
-  if ! grep -q 'export FLEETCTL_ENDPOINT=http://172.17.8.101:4001' ~/.bash_profile ; then
-    echo "export FLEETCTL_ENDPOINT=http://172.17.8.101:4001" >> ~/.bash_profile
+  if ! grep -q 'export FLEETCTL_ENDPOINT=http://172.17.8.101:4001' ${homeDir}/.bash_profile ; then
+    echo "export FLEETCTL_ENDPOINT=http://172.17.8.101:4001" >> ${homeDir}/.bash_profile
   fi
-  if ! grep -q 'export KUBERNETES_MASTER=http://172.17.8.101:8080' ~/.bash_profile ; then
-    echo "export KUBERNETES_MASTER=http://172.17.8.101:8080" >> ~/.bash_profile
+  if ! grep -q 'export KUBERNETES_MASTER=http://172.17.8.101:8080' ${homeDir}/.bash_profile ; then
+    echo "export KUBERNETES_MASTER=http://172.17.8.101:8080" >> ${homeDir}/.bash_profile
   fi
   export FLEETCTL_ENDPOINT=http://172.17.8.101:4001
   export KUBERNETES_MASTER=http://172.17.8.101:8080


### PR DESCRIPTION
This code supports windows when vagrant is run from a linux-like environment like mingw, cygwin etx.
It needs linux, because sed, rm, mv and other linux like commands are used.

One MAJOR change is that it installs and runs kubectl from the coreos master node.
This is the same as the basic coreos vagrant file, so windows users should be used to it.

The order of the code is somewhat changed because of windows support.
If you want I will explain some of the changes later on when I have more time...