### PR TITLE
Specify Ethernet device name in environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ Most aspects of your cluster setup can be customized with environment variables.
 
    [Possible values are `gce`, `gke`, `aws`, `azure`, `vagrant`, `vsphere`, `libvirt-coreos` and `juju`](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/cluster/kube-env.sh#L17). Defaults to `vagrant`.
 
+ - **FLANNEL_IF** defines the name of the Ethernet device inside the CoreOS guest
+
+   Defaults to `eth1`
+
+   The name of Ethernet devices inside the guest OS is controlled by `systemd`. On VirtualBox, the second device is `eth1`, but on VMware Fusion it is named `ens34`.
+
+
 
 So, in order to start, say, a Kubernetes cluster with 3 minion nodes, 2GB of RAM and 2 vCPUs per node one just would do...
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,7 @@ NODE_MEM= ENV['NODE_MEM'] || 1024
 NODE_CPUS = ENV['NODE_CPUS'] || 1
 
 BASE_IP_ADDR = ENV['BASE_IP_ADDR'] || "172.17.8"
+FLANNEL_IF = ENV['FLANNEL_IF'] || "eth1"
 
 DNS_DOMAIN = ENV['DNS_DOMAIN'] || "k8s.local"
 DNS_UPSTREAM_SERVERS = ENV['DNS_UPSTREAM_SERVERS'] || "8.8.8.8:53,8.8.4.4:53"
@@ -348,6 +349,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           sed -i "s|__MASTER_IP__|#{MASTER_IP}|g" /tmp/vagrantfile-user-data
           sed -i "s|__DNS_DOMAIN__|#{DNS_DOMAIN}|g" /tmp/vagrantfile-user-data
           sed -i "s|__ETCD_SEED_CLUSTER__|#{ETCD_SEED_CLUSTER}|g" /tmp/vagrantfile-user-data
+          sed -i "s|__FLANNEL_IF__|#{FLANNEL_IF}|g" /tmp/vagrantfile-user-data
           sed -i "s|__NODE_CPUS__|#{NODE_CPUS}|g" /tmp/vagrantfile-user-data
           sed -i "s|__NODE_MEM__|#{NODE_MEM}|g" /tmp/vagrantfile-user-data
           mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/

--- a/master.yaml
+++ b/master.yaml
@@ -31,7 +31,7 @@ coreos:
     public-ip: $public_ipv4
     metadata: "role=master"
   flannel:
-    interface: eth1
+    interface: __FLANNEL_IF__
   units:
     - name: rpcbind.service
       enable: true

--- a/node.yaml
+++ b/node.yaml
@@ -26,7 +26,7 @@ coreos:
     public-ip: $public_ipv4
     metadata: "role=minion"
   flannel:
-    interface: eth1
+    interface: __FLANNEL_IF__
   units:
     - name: rpcbind.service
       enable: true


### PR DESCRIPTION
The Ethernet interface used by Flannel is hard-coded to `eth1` in 2 `.yaml` files, which works for VirtualBox but not for VMware Fusion --  `systemd` on CoreOS w/Fusion names the interface `ens34`.   An easy way to have this accommodate both hypervisors is via environment variable `FLANNEL_IF`.  Default is still `eth1`.

Tested successfully with the Kubernetes guestbook example app on Fusion 7.1.1.