### PR TITLE
Make kubectlsetup run as user core.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -198,7 +198,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         kHost.trigger.after [:up] do
           info "Installing kubectl for the kubernetes version we just bootstrapped..."
           if OS.windows?
-            run_remote "/bin/sh /home/core/kubectlsetup install"
+            run_remote "sudo -u core /bin/sh /home/core/kubectlsetup install"
           else
             system "./temp/setup install"
           end


### PR DESCRIPTION
On windows I got the following error message. Figured it should run as core.

==> master: Executing remote command "/bin/sh /home/core/kubectlsetup install"...
==> master: unlink:
==> master: cannot unlink '/root/.bash_profile'
==> master: : No such file or directory

==> master: Remote command execution finished.
The command "/bin/sh /home/core/kubectlsetup install" returned a failed exit code. The
error output is shown below:

unlink: cannot unlink '/root/.bash_profile': No such file or directory
