### PR TITLE
homeDir forced for coreos install, provisioned as root...

### DIFF
--- a/setup.tmpl
+++ b/setup.tmpl
@@ -17,6 +17,7 @@ case "$PLATFORM" in
       . /etc/os-release
       if [[ $ID = coreos ]]; then
         targetDir="/opt/bin"
+        HOME="/home/core"
         unlink $HOME/.bash_profile
         cp /usr/share/skel/.bash_profile $HOME/.bash_profile
         chmod 775 $HOME/.bash_profile


### PR DESCRIPTION
Vagrant uses 'run_remote' to execute kubectl installation as root user.
The kubectlsetup is run as root on coreos in windows, but there is no root homedir.
The homedir must be overwritten to force coreos into installing in the right directory.