### PR TITLE
fix vagrant reload cannot update

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -263,6 +263,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
       end
 
+      kHost.trigger.before [:halt, :reload] do
+        run_remote "sudo rm -f /var/lib/coreos-vagrant/vagrantfile-user-data"
+      end
+
       kHost.trigger.before [:destroy] do
         system <<-EOT.prepend("\n\n") + "\n"
           rm -f temp/*


### PR DESCRIPTION
[problem] when we change the setting in the master.yaml or node.yaml and execute vagrant reload --provision, it always fails to reflect the setting updates in VM. we need to reload twice to reflect these change
[source] master.yaml /node.yaml will be copied as var/lib/coreos-vagrant/vagrantfile-user-data, and there's one service watch on the existence of this file. For the vagrant reload case, as the file is already existed, cloudinit will reflect the old version before it's updated when VM restart. It does not read the new file.
[solution] when halt or reload the vms, we should remove the vagrantfile-user-data in each VMs