### PR TITLE
Add advertise-client-urls to etcd2 launch options.

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -27,6 +27,7 @@ coreos:
   etcd2:
     name: __NAME__
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    advertise-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
     initial-cluster: __ETCD_SEED_CLUSTER__
     proxy: on
   fleet:


### PR DESCRIPTION
- As of etcd 2.0.11 (see here: https://github.com/coreos/etcd/releases/tag/v2.0.11)
 the -advertise-client-urls option is mandatory.