### PR TITLE
fixes pires/kubernetes-vagrant-coreos-cluster#97

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -142,6 +142,7 @@ coreos:
           --healthz_port=10248
         Restart=always
         RestartSec=10
+        WorkingDirectory=/root/
   update:
     group: __CHANNEL__
     reboot-strategy: off


### PR DESCRIPTION
kubelets working directory is by default `/`
this patch changes the kubelets wd to /root/ where a
.dockercfg file is placed by the Vagrant script