### PR TITLE
Fixes #115

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -413,7 +413,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       if File.exist?(SSL_FILE)
-        kHost.vm.provision :file, :source => "#{SSL_FILE}", :destination => "/tmp/kube-serviceaccount.key"
+        kHost.vm.provision :file, :source => "#{SSL_FILE}", :destination => "/home/core/kube-serviceaccount.key"
       end
 
       if File.exist?(cfg)

--- a/master.yaml
+++ b/master.yaml
@@ -141,7 +141,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStartPre=/opt/bin/wupiao $private_ipv4:2379/v2/machines
         ExecStart=/opt/bin/kube-apiserver \
-          --service_account_key_file=/tmp/kube-serviceaccount.key \
+          --service_account_key_file=/home/core/kube-serviceaccount.key \
           --service_account_lookup=false \
           --admission_control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
           --allow_privileged=true \
@@ -170,7 +170,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStartPre=/opt/bin/wupiao $private_ipv4:8080
         ExecStart=/opt/bin/kube-controller-manager \
-          --service_account_private_key_file=/tmp/kube-serviceaccount.key \
+          --service_account_private_key_file=/home/core/kube-serviceaccount.key \
           --master=$private_ipv4:8080 \
           --cloud_provider=__CLOUDPROVIDER__ \
           --pod_eviction_timeout=30s \


### PR DESCRIPTION
`/tmp` is removed on VM `halt` so `kube-serviceaccount.key` needs to be stored in a permanent folder.