### PR TITLE
Added DOCKER_OPTIONS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Most aspects of your cluster setup can be customized with environment variables.
    by running `docker login <registry>.<domain>`. All nodes will get it automatically,
    at 'vagrant up', given any modification or update to that file.
 
+ - **DOCKER_OPTIONS** sets the additional `DOCKER_OPTS` for docker service on both master and the nodes. Useful for adding params such as `--insecure-registry`.
+
  - **KUBERNETES_VERSION** defines the specific kubernetes version being used.
 
    Defaults to `0.19.3`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,8 @@ SSL_FILE = File.join(File.dirname(__FILE__), "kube-serviceaccount.key")
 USE_DOCKERCFG = ENV['USE_DOCKERCFG'] || false
 DOCKERCFG = File.expand_path(ENV['DOCKERCFG'] || "~/.dockercfg")
 
+DOCKER_OPTIONS = ENV['DOCKER_OPTIONS'] || ''
+
 KUBERNETES_VERSION = ENV['KUBERNETES_VERSION'] || '0.19.3'
 
 CHANNEL = ENV['CHANNEL'] || 'alpha'
@@ -430,6 +432,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         kHost.vm.provision :shell, :privileged => true,
         inline: <<-EOF
           sed -i"*" "/__PROXY_LINE__/d" /tmp/vagrantfile-user-data
+          sed -i"*" "s,__DOCKER_OPTIONS__,#{DOCKER_OPTIONS},g" /tmp/vagrantfile-user-data
           sed -i"*" "s,__RELEASE__,v#{KUBERNETES_VERSION},g" /tmp/vagrantfile-user-data
           sed -i"*" "s,__CHANNEL__,v#{CHANNEL},g" /tmp/vagrantfile-user-data
           sed -i"*" "s,__NAME__,#{hostname},g" /tmp/vagrantfile-user-data

--- a/master.yaml
+++ b/master.yaml
@@ -126,7 +126,7 @@ coreos:
             Requires=docker-cache.service flanneld.service
             After=docker-cache.service flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='--registry-mirror=http://$private_ipv4:5000'
+            Environment=DOCKER_OPTS='__DOCKER_OPTIONS__ --registry-mirror=http://$private_ipv4:5000'
     - name: kube-apiserver.service
       command: start
       content: |

--- a/node.yaml
+++ b/node.yaml
@@ -97,7 +97,7 @@ coreos:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='--registry-mirror=http://__MASTER_IP__:5000'
+            Environment=DOCKER_OPTS='__DOCKER_OPTIONS__ --registry-mirror=http://__MASTER_IP__:5000'
             ExecStartPre=/opt/bin/wupiao __MASTER_IP__:5000
     - name: kube-proxy.service
       command: start


### PR DESCRIPTION
Fixes pires/kubernetes-vagrant-coreos-cluster#129

The name of the variable is DOCKER_OPTIONS instead of DOCKER_OPTS so it won't collide with users local environment settings.