### PR TITLE
Make Fusion VMs honor specified memory and CPU settings.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -366,6 +366,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           vb.gui = GUI
         end
       end
+      ["vmware_fusion", "vmware_workstation"].each do |h|
+        kHost.vm.provider h do |v|
+          v.vmx["memsize"] = memory
+          v.vmx["numvcpus"] = cpus
+        end
+      end
       ["parallels", "virtualbox"].each do |h|
         kHost.vm.provider h do |n|
           n.memory = memory


### PR DESCRIPTION
This change adds necessary configuration so that VMware Fusion VMs properly reflect the memory and CPU directives specified - defaults or in env vars.

Tested Kubernetes guestbook sample app on Fusion 7.1.2 with following command; observed memory/CPU of running VMs reflected these directives:

`NODE_MEM=3000 NODE_CPUS=2 MASTER_MEM=2000 vagrant up`

