### PR TITLE
Fixes for proxies in services

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -16,12 +16,6 @@ write-files:
           sleep 1 && echo .;
         done;
       exit $?
-  - __PROXY_LINE__path: /etc/systemd/system/docker.service.d/http-proxy.conf
-    __PROXY_LINE__owner: core:core
-    __PROXY_LINE__permissions: '0644'
-    __PROXY_LINE__content: |
-      __PROXY_LINE__[Service]
-      __PROXY_LINE__Environment="HTTP_PROXY=__HTTP_PROXY__" "HTTPS_PROXY=__HTTPS_PROXY__" "NO_PROXY=__NO_PROXY__"
 
 coreos:
   etcd2:
@@ -39,24 +33,6 @@ coreos:
   flannel:
     interface: $public_ipv4
   units:
-    - __PROXY_LINE__name: set-http-proxy.service
-      __PROXY_LINE__command: start
-      __PROXY_LINE__content: |
-        __PROXY_LINE__[Unit]
-        __PROXY_LINE__Description=Set HTTP proxy
-        __PROXY_LINE__DefaultDependencies=no
-        __PROXY_LINE__After=systemd-sysctl.service
-        __PROXY_LINE__Before=sysinit.target
-        __PROXY_LINE__[Service]
-        __PROXY_LINE__Type=oneshot
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment HTTP_PROXY=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment HTTPS_PROXY=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment NO_PROXY=__NO_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment http_proxy=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment https_proxy=__HTTP_PROXY__
-        __PROXY_LINE__ExecStart=/usr/bin/systemctl set-environment no_proxy=__NO_PROXY__
-        __PROXY_LINE__[Install]
-        __PROXY_LINE__WantedBy=multi-user.target
     - name: rpcbind.service
       enable: true
       command: start
@@ -72,6 +48,7 @@ coreos:
         Requires=network-online.target
         After=network-online.target
         [Service]
+        EnvironmentFile=/etc/environment
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/wget -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
@@ -103,6 +80,9 @@ coreos:
           -e MIRROR_SOURCE=https://registry-1.docker.io \
           -e MIRROR_SOURCE_INDEX=https://index.docker.io \
           -e MIRROR_TAGS_CACHE_TTL=1800 \
+          __PROXY_LINE__-e HTTP_PROXY=__HTTP_PROXY__ \
+          __PROXY_LINE__-e HTTPS_PROXY=__HTTPS_PROXY__ \
+          __PROXY_LINE__-e NO_PROXY=__NO_PROXY__ \
           quay.io/devops/docker-registry:latest
     - name: fleet.service
       command: start
@@ -126,19 +106,43 @@ coreos:
             Requires=docker-cache.service flanneld.service
             After=docker-cache.service flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='__DOCKER_OPTIONS__ --registry-mirror=http://$private_ipv4:5000'
+            Environment="DOCKER_OPTS=__DOCKER_OPTIONS__ --registry-mirror=http://$private_ipv4:5000"
+        - __PROXY_LINE__name: http-proxy.conf
+          __PROXY_LINE__content: |
+            __PROXY_LINE__[Service]
+            __PROXY_LINE__EnvironmentFile=/etc/environment
+    - name: early-docker.service
+      drop-ins:
+        - __PROXY_LINE__name: http-proxy.conf
+          __PROXY_LINE__content: |
+            __PROXY_LINE__[Service]
+            __PROXY_LINE__EnvironmentFile=/etc/environment
+    - name: kube-install.service
+      command: start
+      content: |
+        [Unit]
+        Description=Download/Install Kubernetes
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        EnvironmentFile=/etc/environment
+        ExecStart=-/usr/bin/mkdir -p /opt/bin
+        ExecStart=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-apiserver
+        ExecStart=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-controller-manager
+        ExecStart=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-scheduler
+        ExecStart=/usr/bin/chmod +x /opt/bin/kube-apiserver
+        ExecStart=/usr/bin/chmod +x /opt/bin/kube-controller-manager
+        ExecStart=/usr/bin/chmod +x /opt/bin/kube-scheduler
     - name: kube-apiserver.service
       command: start
       content: |
         [Unit]
         Description=Kubernetes API Server
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
-        Requires=etcd2.service docker-cache.service fleet.service docker.service flanneld.service
-        After=etcd2.service docker-cache.service fleet.service docker.service flanneld.service
+        Requires=etcd2.service docker-cache.service fleet.service docker.service flanneld.service kube-install.service
+        After=etcd2.service docker-cache.service fleet.service docker.service flanneld.service kube-install.service
         [Service]
-        ExecStartPre=-/usr/bin/mkdir -p /opt/bin
-        ExecStartPre=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-apiserver
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStartPre=/opt/bin/wupiao $private_ipv4:2379/v2/machines
         ExecStart=/opt/bin/kube-apiserver \
           --service_account_key_file=/home/core/kube-serviceaccount.key \
@@ -166,8 +170,6 @@ coreos:
         Requires=kube-apiserver.service
         After=kube-apiserver.service
         [Service]
-        ExecStartPre=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-controller-manager
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStartPre=/opt/bin/wupiao $private_ipv4:8080
         ExecStart=/opt/bin/kube-controller-manager \
           --service_account_private_key_file=/home/core/kube-serviceaccount.key \
@@ -186,8 +188,6 @@ coreos:
         Requires=kube-apiserver.service
         After=kube-apiserver.service
         [Service]
-        ExecStartPre=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-scheduler
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
         ExecStartPre=/opt/bin/wupiao $private_ipv4:8080
         ExecStart=/opt/bin/kube-scheduler \
           --master=$private_ipv4:8080

--- a/node.yaml
+++ b/node.yaml
@@ -16,12 +16,6 @@ write-files:
           sleep 1 && echo .;
         done;
       exit $?
-  - __PROXY_LINE__path: /etc/systemd/system/docker.service.d/http-proxy.conf
-    __PROXY_LINE__owner: core:core
-    __PROXY_LINE__permissions: '0644'
-    __PROXY_LINE__content: |
-      __PROXY_LINE__[Service]
-      __PROXY_LINE__Environment="HTTP_PROXY=__HTTP_PROXY__" "HTTPS_PROXY=__HTTPS_PROXY__" "NO_PROXY=__NO_PROXY__"
 
 coreos:
   etcd2:
@@ -36,24 +30,6 @@ coreos:
   flannel:
     interface: $public_ipv4
   units:
-    - __PROXY_LINE__name: set-http-proxy.service
-      __PROXY_LINE__command: start
-      __PROXY_LINE__content: |
-        __PROXY_LINE__[Unit]
-        __PROXY_LINE__Description=Set HTTP proxy
-        __PROXY_LINE__DefaultDependencies=no
-        __PROXY_LINE__After=systemd-sysctl.service
-        __PROXY_LINE__Before=sysinit.target
-        __PROXY_LINE__[Service]
-        __PROXY_LINE__Type=oneshot
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment HTTP_PROXY=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment HTTPS_PROXY=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment NO_PROXY=__NO_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment http_proxy=__HTTP_PROXY__
-        __PROXY_LINE__ExecStartPre=/usr/bin/systemctl set-environment https_proxy=__HTTP_PROXY__
-        __PROXY_LINE__ExecStart=/usr/bin/systemctl set-environment no_proxy=__NO_PROXY__
-        __PROXY_LINE__[Install]
-        __PROXY_LINE__WantedBy=multi-user.target
     - name: rpcbind.service
       enable: true
       command: start
@@ -69,6 +45,7 @@ coreos:
         Requires=network-online.target
         After=network-online.target
         [Service]
+        EnvironmentFile=/etc/environment
         ExecStartPre=-/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/wget -P /opt/bin https://github.com/kelseyhightower/setup-network-environment/releases/download/v1.0.0/setup-network-environment
         ExecStartPre=/usr/bin/chmod +x /opt/bin/setup-network-environment
@@ -97,17 +74,42 @@ coreos:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='__DOCKER_OPTIONS__ --registry-mirror=http://__MASTER_IP__:5000'
+            Environment="DOCKER_OPTS=__DOCKER_OPTIONS__ --registry-mirror=http://__MASTER_IP__:5000"
             ExecStartPre=/opt/bin/wupiao __MASTER_IP__:5000
+    - __PROXY_LINE__name: http-proxy.conf
+      __PROXY_LINE__content: |
+        __PROXY_LINE__[Service]
+        __PROXY_LINE__EnvironmentFile=/etc/environment
+    - name: early-docker.service
+      drop-ins:
+        - __PROXY_LINE__name: http-proxy.conf
+          __PROXY_LINE__content: |
+            __PROXY_LINE__[Service]
+            __PROXY_LINE__EnvironmentFile=/etc/environment
+    - name: kube-install.service
+      command: start
+      content: |
+        [Unit]
+        Description=Download/Install Kubernetes
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        EnvironmentFile=/etc/environment
+        ExecStart=-/usr/bin/mkdir -p /opt/bin
+        ExecStart=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-proxy
+        ExecStart=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kubelet
+        ExecStart=/usr/bin/chmod +x /opt/bin/kube-proxy
+        ExecStart=/usr/bin/chmod +x /opt/bin/kubelet
     - name: kube-proxy.service
       command: start
       content: |
         [Unit]
         Description=Kubernetes Proxy
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Requires=kube-install.service
+        After=kube-install.service
         [Service]
-        ExecStartPre=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kube-proxy
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStartPre=/opt/bin/wupiao __MASTER_IP__:8080
         ExecStart=/opt/bin/kube-proxy \
           --master=__MASTER_IP__:8080 \
@@ -120,10 +122,10 @@ coreos:
         [Unit]
         Description=Kubernetes Kubelet
         Documentation=https://github.com/GoogleCloudPlatform/kubernetes
+        Requires=kube-install.service
+        After=kube-install.service
         [Service]
         EnvironmentFile=/etc/network-environment
-        ExecStartPre=/usr/bin/wget -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/__RELEASE__/bin/linux/amd64/kubelet
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStartPre=/usr/bin/mkdir -p /opt/kubernetes/manifests/
         ExecStartPre=/opt/bin/wupiao __MASTER_IP__:8080
         ExecStart=/opt/bin/kubelet \


### PR DESCRIPTION
Having proxy settings for the Kubernetes-api service creates problems, this configuration only uses proxy settings for the services that need it.