### PR TITLE
Use host-gw instead of vxlan 

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -94,7 +94,7 @@ coreos:
             [Unit]
             Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "host-gw"}}'
     - name: docker.service
       command: start
       drop-ins:

--- a/node.yaml
+++ b/node.yaml
@@ -60,7 +60,7 @@ coreos:
             [Unit]
             Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "host-gw"}}'
     - name: fleet.service
       command: start
     - name: docker.service


### PR DESCRIPTION
to reduce network overhead since vxlan is not needed when all nodes share the same L2 domain. 