### PR TITLE
Add CRLF to LF comment for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ brew install wget
 
 ### Windows
 
-The [vagrant-winnfsd plugin](https://github.com/GM-Alex/vagrant-winnfsd) will be installed in order to enable NFS shares.
+- The [vagrant-winnfsd plugin](https://github.com/GM-Alex/vagrant-winnfsd) will be installed in order to enable NFS shares.
+- The project will run some bash script under the VirtualMachines. These scripts line ending need to be in LF. Git for windows set `core.autocrlf true` by default at the installation time. When you clone this project repository, this parameter (set to true) ask git to change all line ending to CRLF. This behavior need to be changed before cloning the repository (or after for each files by hand). We recommand to turn this to off by running `git config --global core.autocrlf false` before cloning. Then, after cloning, do not forget to turn the behavior back if you want to run other windows projects: `git config --global core.autocrlf true`.
 
 ## Deploy Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install wget
 ### Windows
 
 - The [vagrant-winnfsd plugin](https://github.com/GM-Alex/vagrant-winnfsd) will be installed in order to enable NFS shares.
-- The project will run some bash script under the VirtualMachines. These scripts line ending need to be in LF. Git for windows set `core.autocrlf true` by default at the installation time. When you clone this project repository, this parameter (set to true) ask git to change all line ending to CRLF. This behavior need to be changed before cloning the repository (or after for each files by hand). We recommand to turn this to off by running `git config --global core.autocrlf false` before cloning. Then, after cloning, do not forget to turn the behavior back if you want to run other windows projects: `git config --global core.autocrlf true`.
+- The project will run some bash script under the VirtualMachines. These scripts line ending need to be in LF. Git for windows set `core.autocrlf true` by default at the installation time. When you clone this project repository, this parameter (set to true) ask git to change all line ending to CRLF. This behavior need to be changed before cloning the repository (or after for each files by hand). We recommand to turn this to off by running `git config --global core.autocrlf false` and `git config --global core.eol lf` before cloning. Then, after cloning, do not forget to turn the behavior back if you want to run other windows projects: `git config --global core.autocrlf true` and `git config --global core.eol crlf`.
 
 ## Deploy Kubernetes
 


### PR DESCRIPTION
Hey, this PR add a comment for Windows user as they need to switch off a WindowsGit behavior.

We previously have added a .gitattributes file. But this one protect the repository, it doesn't change the update of all LF to CRLF for windows user with `core.autocrlf` set to `true` (the default behavior).