### PR TITLE
Avoid download binaries on subsequent vagrant up

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -101,6 +101,9 @@ coreos:
         Requires=network-online.target kube-certs.service
         After=network-online.target kube-certs.service
         ConditionPathExists=/srv/kubernetes
+        ConditionPathExists=!/opt/bin/kube-apiserver
+        ConditionPathExists=!/opt/bin/kube-controller-manager
+        ConditionPathExists=!/opt/bin/kube-scheduler
         [Service]
         Type=oneshot
         EnvironmentFile=/etc/environment

--- a/node.yaml
+++ b/node.yaml
@@ -77,6 +77,8 @@ coreos:
         Description=Download/Install Kubernetes
         Requires=network-online.target
         After=network-online.target
+        ConditionPathExists=!/opt/bin/kube-proxy
+        ConditionPathExists=!/opt/bin/kubelet
         [Service]
         Type=oneshot
         EnvironmentFile=/etc/environment

--- a/setup.tmpl
+++ b/setup.tmpl
@@ -31,7 +31,7 @@ esac
 if [[ "$#" -eq 1 && "$1" == "install"  ]] ; then
   echo "Downloading and installing ${PLATFORM} version of 'kubectl' v${KUBERNETES_VERSION} into ${targetDir}. This may take a couple minutes, depending on your internet speed.."
   [ -d ${targetDir} ] || sudo mkdir -p ${targetDir}
-  sudo -E wget -q --no-check-certificate -L -O ${targetDir}/kubectl "${KUB_URL}"
+  [ -e ${targetDir}/kubectl ] || sudo -E wget -q --no-check-certificate -L -O ${targetDir}/kubectl "${KUB_URL}"
   [ -x ${targetDir}/kubectl ] || sudo chmod +x ${targetDir}/kubectl
 
   # use sed to replace current values, if any; create profile file if not exists


### PR DESCRIPTION
Instead of downloading the binaries everytime vagrant up is done, do
a ConditionalPath to check for binaries. This also prevents the kubectl
from getting downloaded if there is already a kubectl in /usr/local/bin

Please note that this does not check the version of kubectl but just the
existence.