### PR TITLE
Avoid download binaries on subsequent vagrant up

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -101,6 +101,9 @@ coreos:
         Requires=network-online.target kube-certs.service
         After=network-online.target kube-certs.service
         ConditionPathExists=/srv/kubernetes
+        ConditionPathExists=!/opt/bin/kube-apiserver
+        ConditionPathExists=!/opt/bin/kube-controller-manager
+        ConditionPathExists=!/opt/bin/kube-scheduler
         [Service]
         Type=oneshot
         EnvironmentFile=/etc/environment

--- a/node.yaml
+++ b/node.yaml
@@ -77,6 +77,8 @@ coreos:
         Description=Download/Install Kubernetes
         Requires=network-online.target
         After=network-online.target
+        ConditionPathExists=!/opt/bin/kube-proxy
+        ConditionPathExists=!/opt/bin/kubelet
         [Service]
         Type=oneshot
         EnvironmentFile=/etc/environment


### PR DESCRIPTION
Instead of downloading the binaries everytime vagrant up is done, do
a ConditionalPath to check for binaries.

This fixes #186 