### PR TITLE
Use HTTP.new instead of HTTP.start

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -279,7 +279,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               urlDomain = "storage.googleapis.com"
               urlResource = "/kubernetes-release/release/v#{KUBERNETES_VERSION}/bin/linux/amd64/#{filename}"
               info "Trying to download #{urlDomain}#{urlResource}..."
-              Net::HTTP.start(urlDomain) do |http|
+              Net::HTTP.new(urlDomain).start do |http|
                   resp = http.get(urlResource)
                   open(file, "wb") do |f|
                     f.write(resp.body)


### PR DESCRIPTION
It appears Net:HTTP in Ruby 2.2.0 (in Vagrant 1.8.5) does not respect
the "http_proxy" env variable in HTTP.start, but it works in HTTP.new