### PR TITLE
Solve issue with latest kube-dns

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -127,7 +127,7 @@ coreos:
           --volume=/sys:/sys:ro \
           --volume=/etc/kubernetes:/etc/kubernetes:ro \
           --volume=/var/lib/docker/:/var/lib/docker:rw \
-          --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+          --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
           --volume=/var/run:/var/run:rw \
           --net=host \
           --pid=host \


### PR DESCRIPTION
Without this one have the following error with kube-dns / kubedns container:

```
Failed to create a kubernetes client: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
```