### PR TITLE
Fixes to README and Vagrantfile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .vagrant
 .dockercfg
+.editorconfig
+.ruby-gemset
+.ruby-version
 temp/*
 synced_folders.yaml
 artifacts/*

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ vagrant plugin install vagrant-parallels
 Then just add ```--provider parallels``` to the ```vagrant up``` invocations above.
 
 ### VMware
-If you are using one of the **VMware** hypervisors you must **[buy](http://www.vagrantup.com/vmware)** the matching  provider and, depending on your case, just add either ```--provider vmware-fusion``` or ```--provider vmware-workstation``` to the ```vagrant up``` invocations above.
+If you are using one of the **VMware** hypervisors you must **[buy](http://www.vagrantup.com/vmware)** the matching  provider and, depending on your case, just add either ```--provider vmware_fusion``` or ```--provider vmware_workstation``` to the ```vagrant up``` invocations above.
 
 ## Private Docker Repositories
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ REMOVE_VAGRANTFILE_USER_DATA_BEFORE_HALT = (ENV['REMOVE_VAGRANTFILE_USER_DATA_BE
 # if this is set true, remember to use --provision when executing vagrant up / reload
 
 # Read YAML file with mountpoint details
-MOUNT_POINTS = YAML::load_file('synced_folders.yaml')
+MOUNT_POINTS = YAML::load_file(File.join(File.dirname(__FILE__), "synced_folders.yaml"))
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # always use host timezone in VMs


### PR DESCRIPTION
Providers specified incorrectly in README. Expanded path for "synced_folders.yaml" in Vagrantfile so you can use vagrant commands outside of the repo directory.