### PR TITLE
Perform token replacement on every boot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -571,7 +571,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             s.privileged = true
           end
         end
-        kHost.vm.provision :shell, :privileged => true,
+        kHost.vm.provision :shell, run: "always", :privileged => true,
         inline: <<-EOF
           sed -i"*" "s,__RELEASE__,v#{KUBERNETES_VERSION},g" /etc/kubernetes/manifests/*.yaml
           sed -i"*" "s|__MASTER_IP__|#{MASTER_IP}|g" /etc/kubernetes/manifests/*.yaml


### PR DESCRIPTION
Fixes issue when Kubernetes doesn't start on second and later boot cycles. `/vagrant/manifests/*.yaml` are copied to guest machines on every boot while the token replacement is done only on the first.

Fixes #243