### PR TITLE
Fixes for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+
+# Force LF line ending on these files
+* eol=lf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -505,6 +505,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         kHost.vm.provider h do |v|
           v.vmx["memsize"] = memory
           v.vmx["numvcpus"] = cpus
+          v.vmx['virtualHW.version'] = 10
         end
       end
       ["parallels", "virtualbox"].each do |h|


### PR DESCRIPTION
Fix weird VM virtual hardware incompatibility.  The CoreOS VM wouldn't boot on Workstation without upgrading the virtual hardware... Something about AVX2 or something.  It can be passed in from the Vagrantfile.  This sets the virtual hardware to version 10, compatible with Fusion 6+, Workstation 10+ and ESXi 5.5+

This error could only be seen in the VMware logs:
```
This virtual machine requires AVX2 but AVX is not present.
```

Also, use .gitattributes to ensure we always checkout with proper line endings.