### PR TITLE
Add kubernetes 1.8 compatibility

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -148,7 +148,6 @@ coreos:
           gcr.io/google_containers/hyperkube-amd64:__RELEASE__ \
             /hyperkube kubelet \
             --address=$private_ipv4 \
-            --api-servers=http://127.0.0.1:8080 \
             --network-plugin-dir=/etc/kubernetes/cni/net.d \
             --network-plugin= \
             --register-schedulable=false \
@@ -156,7 +155,8 @@ coreos:
             --pod-manifest-path=/etc/kubernetes/manifests \
             --hostname-override=$public_ipv4 \
             --cluster_dns=10.100.0.10 \
-            --cluster_domain=__DNS_DOMAIN__
+            --cluster_domain=__DNS_DOMAIN__ \
+            --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml
         Restart=on-failure
         RestartSec=10
         WorkingDirectory=/root/

--- a/node.yaml
+++ b/node.yaml
@@ -136,7 +136,6 @@ coreos:
             /hyperkube kubelet \
             --containerized \
             --address=$private_ipv4 \
-            --api-servers=http://__MASTER_IP__:8080 \
             --network-plugin-dir=/etc/kubernetes/cni/net.d \
             --network-plugin= \
             --allow-privileged=true \

--- a/tls/master-kubeconfig.yaml
+++ b/tls/master-kubeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: http://127.0.0.1:8080
+users:
+- name: kubelet
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context

--- a/tls/node-kubeconfig.yaml
+++ b/tls/node-kubeconfig.yaml
@@ -3,6 +3,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
+    server: http://__MASTER_IP__:8080
     certificate-authority: /etc/kubernetes/ssl/ca.pem
 users:
 - name: kubelet


### PR DESCRIPTION
The `--api-servers` argument was removed in 1.8 and deprecated long before in favor of kubeconfig