### PR TITLE
Switched to secured k8s API endpoint (#285)

### DIFF
--- a/manifests/node-proxy.yaml
+++ b/manifests/node-proxy.yaml
@@ -11,7 +11,7 @@ spec:
     command:
       - /hyperkube
       - proxy
-      - --master=http://__MASTER_IP__:8080
+      - --master=https://__MASTER_IP__:443
       - --kubeconfig=/etc/kubernetes/node-kubeconfig.yaml
       - --proxy-mode=iptables
     securityContext:

--- a/tls/node-kubeconfig.yaml
+++ b/tls/node-kubeconfig.yaml
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: http://__MASTER_IP__:8080
+    server: https://__MASTER_IP__:443
     certificate-authority: /etc/kubernetes/ssl/ca.pem
 users:
 - name: kubelet


### PR DESCRIPTION
I think it is ok to still use 8080/http on master node because it basically connects to itself. I only switched to https on worker's `kubelet` and worker's `kube-proxy`
See #285 
I checked that Nodes are ready (kubectl get nodes) and there are no additional problems in logs of kube-proxy.