### PR TITLE
Use Calico for cluster networking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Most aspects of your cluster setup can be customized with environment variables.
 
    Defaults to `AlwaysAllow`.
 
+ - **CLUSTER_CIDR** defines the CIDR to be used for pod networking. This CIDR must not overlap with `10.100.0.0/16`.
+
+   Defaults to `10.244.0.0/16`.
+
 So, in order to start, say, a Kubernetes cluster with 3 worker nodes, 4GB of RAM and 4 vCPUs per node one just would run:
 
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -166,6 +166,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # in CoreOS, so tell Vagrant that so it can be smarter.
     v.check_guest_additions = false
     v.functional_vboxsf     = false
+    v.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
   end
   config.vm.provider :parallels do |p|
     p.update_guest_tools = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -138,6 +138,9 @@ REMOVE_VAGRANTFILE_USER_DATA_BEFORE_HALT = (ENV['REMOVE_VAGRANTFILE_USER_DATA_BE
 # Read YAML file with mountpoint details
 MOUNT_POINTS = YAML::load_file(File.join(File.dirname(__FILE__), "synced_folders.yaml"))
 
+# CLUSTER_CIDR is the CIDR used for pod networking
+CLUSTER_CIDR = ENV['CLUSTER_CIDR'] || "10.244.0.0/16"
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # always use host timezone in VMs
   config.timezone.value = :host
@@ -324,6 +327,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
           info "Configuring Calico..."
 
+          # Replace __CLUSTER_CIDR__ in calico.yaml.tmpl with the value of CLUSTER_CIDR
+          calicoTmpl = File.read("#{__dir__}/plugins/calico/calico.yaml.tmpl")
+          calicoTmpl = calicoTmpl.gsub("__CLUSTER_CIDR__", CLUSTER_CIDR);
+          File.open("#{__dir__}/temp/calico.yaml", "wb") do |f|
+            f.write(calicoTmpl)
+          end
+
+          # Install Calico
           if OS.windows?
             if AUTHORIZATION_MODE == "RBAC"
               run_remote "/opt/bin/kubectl apply -f /home/core/calico-rbac.yaml"
@@ -333,7 +344,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             if AUTHORIZATION_MODE == "RBAC"
               system "kubectl apply -f plugins/calico/calico-rbac.yaml"
             end
-            system "kubectl apply -f plugins/calico/calico.yaml"
+            system "kubectl apply -f temp/calico.yaml"
           end
 
           info "Configuring Kubernetes DNS..."
@@ -412,7 +423,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "temp/setup"), :destination => "/home/core/kubectlsetup"
 
           kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/calico/calico-rbac.yaml"), :destination => "/home/core/calico-rbac.yaml"
-          kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/calico/calico.yaml"), :destination => "/home/core/calico.yaml"
+          kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "temp/calico.yaml"), :destination => "/home/core/calico.yaml"
 
           if DNS_PROVIDER == "kube-dns"
               kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/dns/kube-dns/dns-configmap.yaml"), :destination => "/home/core/dns-configmap.yaml"
@@ -614,6 +625,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           sed -i"*" "s,__RELEASE__,v#{KUBERNETES_VERSION},g" /etc/kubernetes/manifests/*.yaml
           sed -i"*" "s|__MASTER_IP__|#{MASTER_IP}|g" /etc/kubernetes/manifests/*.yaml
           sed -i"*" "s|__DNS_DOMAIN__|#{DNS_DOMAIN}|g" /etc/kubernetes/manifests/*.yaml
+          sed -i"*" "s|__CLUSTER_CIDR__|#{CLUSTER_CIDR}|g" /etc/kubernetes/manifests/*.yaml
         EOF
       end
 
@@ -639,6 +651,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           sed -i"*" "s|__MASTER_IP__|#{MASTER_IP}|g" /tmp/vagrantfile-user-data
           sed -i"*" "s|__DNS_DOMAIN__|#{DNS_DOMAIN}|g" /tmp/vagrantfile-user-data
           sed -i"*" "s|__ETCD_SEED_CLUSTER__|#{ETCD_SEED_CLUSTER}|g" /tmp/vagrantfile-user-data
+          sed -i"*" "s|__CLUSTER_CIDR__|#{CLUSTER_CIDR}|g" /tmp/vagrantfile-user-data
           mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/
         EOF
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -322,6 +322,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             system "kubectl config use-context local"
           end
 
+          info "Configuring Calico..."
+
+          if OS.windows?
+            if AUTHORIZATION_MODE == "RBAC"
+              run_remote "/opt/bin/kubectl apply -f /home/core/calico-rbac.yaml"
+            end
+            run_remote "/opt/bin/kubectl apply -f /home/core/calico.yaml"
+          else
+            if AUTHORIZATION_MODE == "RBAC"
+              system "kubectl apply -f plugins/calico/calico-rbac.yaml"
+            end
+            system "kubectl apply -f plugins/calico/calico.yaml"
+          end
+
           info "Configuring Kubernetes DNS..."
 
           if DNS_PROVIDER == "kube-dns"
@@ -396,6 +410,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # copy setup files to master vm if host is windows
         if OS.windows?
           kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "temp/setup"), :destination => "/home/core/kubectlsetup"
+
+          kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/calico/calico-rbac.yaml"), :destination => "/home/core/calico-rbac.yaml"
+          kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/calico/calico.yaml"), :destination => "/home/core/calico.yaml"
 
           if DNS_PROVIDER == "kube-dns"
               kHost.vm.provision :file, :source => File.join(File.dirname(__FILE__), "plugins/dns/kube-dns/dns-configmap.yaml"), :destination => "/home/core/dns-configmap.yaml"

--- a/manifests/master-controller-manager.yaml
+++ b/manifests/master-controller-manager.yaml
@@ -16,7 +16,7 @@ spec:
       - --root-ca-file=/etc/kubernetes/ssl/ca.pem
       - --cluster-signing-cert-file=/etc/kubernetes/ssl/ca.pem
       - --cluster-signing-key-file=/etc/kubernetes/ssl/ca-key.pem
-      - --cluster-cidr=192.168.0.0/16
+      - --cluster-cidr=__CLUSTER_CIDR__
       - --allocate-node-cidrs=true
     livenessProbe:
       httpGet:

--- a/manifests/master-controller-manager.yaml
+++ b/manifests/master-controller-manager.yaml
@@ -16,6 +16,8 @@ spec:
       - --root-ca-file=/etc/kubernetes/ssl/ca.pem
       - --cluster-signing-cert-file=/etc/kubernetes/ssl/ca.pem
       - --cluster-signing-key-file=/etc/kubernetes/ssl/ca-key.pem
+      - --cluster-cidr=192.168.0.0/16
+      - --allocate-node-cidrs=true
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/manifests/master-proxy.yaml
+++ b/manifests/master-proxy.yaml
@@ -13,7 +13,7 @@ spec:
       - proxy
       - --master=http://__MASTER_IP__:8080
       - --proxy-mode=iptables
-      - --cluster-cidr=192.168.0.0/16
+      - --cluster-cidr=__CLUSTER_CIDR__
     securityContext:
       privileged: true
     volumeMounts:

--- a/manifests/master-proxy.yaml
+++ b/manifests/master-proxy.yaml
@@ -13,6 +13,7 @@ spec:
       - proxy
       - --master=http://__MASTER_IP__:8080
       - --proxy-mode=iptables
+      - --cluster-cidr=192.168.0.0/16
     securityContext:
       privileged: true
     volumeMounts:

--- a/manifests/node-proxy.yaml
+++ b/manifests/node-proxy.yaml
@@ -14,7 +14,7 @@ spec:
       - --master=https://__MASTER_IP__:443
       - --kubeconfig=/etc/kubernetes/node-kubeconfig.yaml
       - --proxy-mode=iptables
-      - --cluster-cidr=192.168.0.0/16
+      - --cluster-cidr=__CLUSTER_CIDR__
     securityContext:
       privileged: true
     volumeMounts:

--- a/manifests/node-proxy.yaml
+++ b/manifests/node-proxy.yaml
@@ -14,6 +14,7 @@ spec:
       - --master=https://__MASTER_IP__:443
       - --kubeconfig=/etc/kubernetes/node-kubeconfig.yaml
       - --proxy-mode=iptables
+      - --cluster-cidr=192.168.0.0/16
     securityContext:
       privileged: true
     volumeMounts:

--- a/master.yaml
+++ b/master.yaml
@@ -144,7 +144,7 @@ coreos:
             --cluster_domain=__DNS_DOMAIN__ \
             --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml \
             --network-plugin=cni \
-            --pod-cidr=192.168.0.0/16
+            --pod-cidr=__CLUSTER_CIDR__
         Restart=on-failure
         RestartSec=10
         WorkingDirectory=/root/

--- a/master.yaml
+++ b/master.yaml
@@ -18,8 +18,6 @@ write-files:
       exit $?
 
 coreos:
-  flannel:
-    interface: $public_ipv4
   units:
     - name: rpcbind.service
       enable: true
@@ -50,15 +48,6 @@ coreos:
             --initial-cluster __ETCD_SEED_CLUSTER__
         [Install]
         WantedBy=multi-user.target
-    - name: flanneld.service
-      command: start
-      drop-ins:
-        - name: 50-network-config.conf
-          content: |
-            [Unit]
-            Requires=etcd-member.service
-            [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "host-gw"}}'
     - name: docker.service
       command: start
       drop-ins:
@@ -67,11 +56,6 @@ coreos:
           __PROXY_LINE__content: |
             __PROXY_LINE__[Service]
             __PROXY_LINE__EnvironmentFile=/etc/environment
-        - name: 40-flannel.conf
-          content: |
-            [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
         - name: 50-docker-options.conf
           content: |
             [Service]
@@ -136,9 +120,12 @@ coreos:
         ExecStart=/usr/bin/docker run \
           --volume=/:/rootfs:ro \
           --volume=/sys:/sys:ro \
+          --volume=/etc/cni/net.d:/etc/cni/net.d:rw \
+          --volume=/opt/cni/bin:/opt/cni/bin:rw \
           --volume=/etc/kubernetes:/etc/kubernetes:ro \
+          --volume=/var/lib/calico/:/var/lib/calico:rw \
           --volume=/var/lib/docker/:/var/lib/docker:rw \
-          --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+          --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
           --volume=/var/run:/var/run:rw \
           --net=host \
           --pid=host \
@@ -147,15 +134,17 @@ coreos:
           -d \
           gcr.io/google_containers/hyperkube-amd64:__RELEASE__ \
             /hyperkube kubelet \
+            --containerized \
             --address=$private_ipv4 \
-            --network-plugin= \
             --register-schedulable=false \
             --allow-privileged=true \
             --pod-manifest-path=/etc/kubernetes/manifests \
             --hostname-override=$public_ipv4 \
             --cluster_dns=10.100.0.10 \
             --cluster_domain=__DNS_DOMAIN__ \
-            --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml
+            --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml \
+            --network-plugin=cni \
+            --pod-cidr=192.168.0.0/16
         Restart=on-failure
         RestartSec=10
         WorkingDirectory=/root/

--- a/node.yaml
+++ b/node.yaml
@@ -18,8 +18,6 @@ write-files:
       exit $?
 
 coreos:
-  flannel:
-    interface: $public_ipv4
   units:
     - name: rpcbind.service
       enable: true
@@ -51,15 +49,6 @@ coreos:
             --initial-cluster __ETCD_SEED_CLUSTER__
         [Install]
         WantedBy=multi-user.target
-    - name: flanneld.service
-      command: start
-      drop-ins:
-        - name: 50-network-config.conf
-          content: |
-            [Unit]
-            Requires=etcd-member.service
-            [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "host-gw"}}'
     - name: docker.service
       command: start
       drop-ins:
@@ -68,11 +57,6 @@ coreos:
           __PROXY_LINE__content: |
             __PROXY_LINE__[Service]
             __PROXY_LINE__EnvironmentFile=/etc/environment
-        - name: 40-flannel.conf
-          content: |
-            [Unit]
-            Requires=flanneld.service
-            After=flanneld.service
         - name: 50-docker-options.conf
           content: |
             [Service]
@@ -123,7 +107,10 @@ coreos:
         ExecStart=/usr/bin/docker run \
           --volume=/:/rootfs:ro \
           --volume=/sys:/sys:ro \
+          --volume=/etc/cni/net.d:/etc/cni/net.d:rw \
+          --volume=/opt/cni/bin:/opt/cni/bin:rw \
           --volume=/etc/kubernetes:/etc/kubernetes:ro \
+          --volume=/var/lib/calico/:/var/lib/calico:rw \
           --volume=/var/lib/docker/:/var/lib/docker:rw \
           --volume=/var/lib/kubelet/:/var/lib/kubelet:shared \
           --volume=/var/run:/var/run:rw \
@@ -136,7 +123,6 @@ coreos:
             /hyperkube kubelet \
             --containerized \
             --address=$private_ipv4 \
-            --network-plugin= \
             --allow-privileged=true \
             --pod-manifest-path=/etc/kubernetes/manifests \
             --hostname-override=$public_ipv4 \
@@ -144,7 +130,9 @@ coreos:
             --cluster_domain=__DNS_DOMAIN__ \
             --kubeconfig=/etc/kubernetes/node-kubeconfig.yaml \
             --tls-cert-file=/etc/kubernetes/ssl/node.pem \
-            --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem
+            --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem \
+            --network-plugin=cni \
+            --pod-cidr=192.168.0.0/16
         Restart=on-failure
         RestartSec=10
         WorkingDirectory=/root/

--- a/node.yaml
+++ b/node.yaml
@@ -132,7 +132,7 @@ coreos:
             --tls-cert-file=/etc/kubernetes/ssl/node.pem \
             --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem \
             --network-plugin=cni \
-            --pod-cidr=192.168.0.0/16
+            --pod-cidr=__CLUSTER_CIDR__
         Restart=on-failure
         RestartSec=10
         WorkingDirectory=/root/

--- a/plugins/calico/calico-rbac.yaml
+++ b/plugins/calico/calico-rbac.yaml
@@ -1,0 +1,92 @@
+# Calico Version v3.1.1
+# https://docs.projectcalico.org/v3.1/releases#v3.1.1
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - clusterinformations
+      - hostendpoints
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system

--- a/plugins/calico/calico.yaml
+++ b/plugins/calico/calico.yaml
@@ -1,0 +1,477 @@
+# Calico Version v3.1.1
+# https://docs.projectcalico.org/v3.1/releases#v3.1.1
+# This manifest includes the following component versions:
+#   calico/node:v3.1.1
+#   calico/cni:v3.1.1
+
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
+  # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
+  # essential.
+  typha_service_name: "none"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": 1500,
+          "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+          },
+          "policy": {
+            "type": "k8s"
+          },
+          "kubernetes": {
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+
+---
+
+# This manifest creates a Service, which will be backed by Calico's Typha daemon.
+# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  ports:
+    - port: 5473
+      protocol: TCP
+      targetPort: calico-typha
+      name: calico-typha
+  selector:
+    k8s-app: calico-typha
+
+---
+
+# This manifest creates a Deployment of Typha to back the above service.
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+  # typha_service_name variable in the calico-config ConfigMap above.
+  #
+  # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+  # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+  # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+  replicas: 0
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-typha
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
+        # add-on, ensuring it gets priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # as a host-networked pod.
+      serviceAccountName: calico-node
+      containers:
+      - image: quay.io/calico/typha:v0.7.2
+        name: calico-typha
+        ports:
+        - containerPort: 5473
+          name: calico-typha
+          protocol: TCP
+        env:
+          # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+          - name: TYPHA_LOGSEVERITYSCREEN
+            value: "info"
+          # Disable logging to file and syslog since those don't make sense in Kubernetes.
+          - name: TYPHA_LOGFILEPATH
+            value: "none"
+          - name: TYPHA_LOGSEVERITYSYS
+            value: "none"
+          # Monitor the Kubernetes API to find the number of running instances and rebalance
+          # connections.
+          - name: TYPHA_CONNECTIONREBALANCINGMODE
+            value: "kubernetes"
+          - name: TYPHA_DATASTORETYPE
+            value: "kubernetes"
+          - name: TYPHA_HEALTHENABLED
+            value: "true"
+          # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
+          # this opens a port on the host, which may need to be secured.
+          #- name: TYPHA_PROMETHEUSMETRICSENABLED
+          #  value: "true"
+          #- name: TYPHA_PROMETHEUSMETRICSPORT
+          #  value: "9093"
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9098
+          periodSeconds: 30
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9098
+          periodSeconds: 10
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+        # Make sure calico/node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v3.1.1
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix info logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              value: "1440"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Enable IP-in-IP within Felix.
+            - name: FELIX_IPINIPENABLED
+              value: "true"
+            # Typha support: controlled by the ConfigMap.
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v3.1.1
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+
+# Create all the CustomResourceDefinitions needed for
+# Calico policy and networking mode.
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Felix Configuration
+kind: CustomResourceDefinition
+metadata:
+   name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico BGP Peers
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico BGP Configuration
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico IP Pools
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico HostEndpoints
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Cluster Information
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Sets
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system

--- a/plugins/calico/calico.yaml.tmpl
+++ b/plugins/calico/calico.yaml.tmpl
@@ -228,7 +228,7 @@ spec:
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
             - name: CALICO_IPV4POOL_CIDR
-              value: "192.168.0.0/16"
+              value: "__CLUSTER_CIDR__"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "Always"


### PR DESCRIPTION
This PR introduces Calico v3.1, replacing flannel as the overlay network. The cluster CIDR is being changed to `192.168.0.0/16`, which is Calico's default. `{master,node}.yaml` also saw some minor adjustments in order to allow Calico to be properly installed and used.

3bb41db is a required fix fox the VMs to boot with recent CoreOS versions. It is included for ease of testing even though it is unrelated to Calico. Please let me know if you'd like a separate PR for that.

Closes #282.
Closes #208.