### PR TITLE
Fix RBAC privilege escalation errors.

### DIFF
--- a/tls/make-certs-master.sh
+++ b/tls/make-certs-master.sh
@@ -37,5 +37,5 @@ cp $pem_ca $pem_ca_key /vagrant/artifacts/tls
 
 # Generate admin
 openssl genrsa -out $pem_admin_key 2048
-openssl req -new -key $pem_admin_key -out $pem_admin_csr -subj "/CN=kube-admin"
+openssl req -new -key $pem_admin_key -out $pem_admin_csr -subj "/CN=kube-admin/O=system:masters"
 openssl x509 -req -in $pem_admin_csr -CA $pem_ca -CAkey $pem_ca_key -CAcreateserial -out $pem_admin -days 365


### PR DESCRIPTION
While running `vagrant up`, the following error pops up even if RBAC is disabled:

```
Error from server (Forbidden): error when creating "temp/coredns-deployment.yaml": clusterroles.rbac.authorization.k8s.io "system:coredns" is forbidden: attempt to grant extra privileges: [PolicyRule{APIGroups:[""], Resources:["endpoints"], Verbs:["list"]} PolicyRule{APIGroups:[""], Resources:["endpoints"], Verbs:["watch"]} PolicyRule{APIGroups:[""], Resources:["services"], Verbs:["list"]} PolicyRule{APIGroups:[""], Resources:["services"], Verbs:["watch"]} PolicyRule{APIGroups:[""], Resources:["pods"], Verbs:["list"]} PolicyRule{APIGroups:[""], Resources:["pods"], Verbs:["watch"]} PolicyRule{APIGroups:[""], Resources:["namespaces"], Verbs:["list"]} PolicyRule{APIGroups:[""], Resources:["namespaces"], Verbs:["watch"]}] user=&{kube-admin  [system:authenticated] map[]} ownerrules=[] ruleResolutionErrors=[]
```

[This discussion](https://gist.githubusercontent.com/jbguerraz/cfdf8c13705d76e4e4ed92389f9cd884/raw/5cf0f7681a01f585f934f8af9243325df64edd25/gistfile1.txt) provides insightful information about why this happens. This PR fixes the error by placing the admin user in the `system:masters` group.